### PR TITLE
Optimize Kubernetes CPU requests and add documentation

### DIFF
--- a/deploy/k8s/deployments/adminer-deployment.yaml
+++ b/deploy/k8s/deployments/adminer-deployment.yaml
@@ -34,7 +34,7 @@ spec:
             periodSeconds: 10
           resources:
             requests:
-              cpu: "50m"
+              cpu: "25m"  # Was 50m
               memory: "64Mi"
             limits:
               cpu: "200m"

--- a/deploy/k8s/deployments/api-gateway-deployment.yaml
+++ b/deploy/k8s/deployments/api-gateway-deployment.yaml
@@ -46,7 +46,7 @@ spec:
             periodSeconds: 10
           resources:
             requests:
-              cpu: "250m"
+              cpu: "150m" # Was 250m
               memory: "512Mi"
             limits:
               cpu: "1"

--- a/deploy/k8s/deployments/config-server-deployment.yaml
+++ b/deploy/k8s/deployments/config-server-deployment.yaml
@@ -57,7 +57,7 @@ spec:
             periodSeconds: 10
           resources:
             requests:
-              cpu: "250m"
+              cpu: "150m" # Was 250m
               memory: "512Mi"
             limits:
               cpu: "1"

--- a/deploy/k8s/deployments/department-service-deployment.yaml
+++ b/deploy/k8s/deployments/department-service-deployment.yaml
@@ -73,7 +73,7 @@ spec:
             periodSeconds: 10
           resources:
             requests:
-              cpu: "250m"
+              cpu: "150m" # Was 250m
               memory: "512Mi"
             limits:
               cpu: "1"

--- a/deploy/k8s/deployments/employee-service-deployment.yaml
+++ b/deploy/k8s/deployments/employee-service-deployment.yaml
@@ -75,7 +75,7 @@ spec:
             periodSeconds: 10
           resources:
             requests:
-              cpu: "250m"
+              cpu: "150m" # Was 250m
               memory: "512Mi"
             limits:
               cpu: "1"

--- a/deploy/k8s/deployments/frontend-deployment.yaml
+++ b/deploy/k8s/deployments/frontend-deployment.yaml
@@ -35,7 +35,7 @@ spec:
             periodSeconds: 5
           resources:
             requests:
-              cpu: "100m"
+              cpu: "75m"  # Was 100m
               memory: "128Mi" # Adjusted as frontend might be lower
             limits:
               cpu: "500m"

--- a/deploy/k8s/deployments/grafana-deployment.yaml
+++ b/deploy/k8s/deployments/grafana-deployment.yaml
@@ -46,7 +46,7 @@ spec:
             periodSeconds: 10
           resources:
             requests:
-              cpu: "100m"
+              cpu: "50m"  # Was 100m
               memory: "256Mi"
             limits:
               cpu: "500m"

--- a/deploy/k8s/deployments/kibana-deployment.yaml
+++ b/deploy/k8s/deployments/kibana-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             periodSeconds: 10
           resources:
             requests:
-              cpu: "100m"
+              cpu: "50m"  # Was 100m
               memory: "256Mi"
             limits:
               cpu: "500m"

--- a/deploy/k8s/deployments/logstash-deployment.yaml
+++ b/deploy/k8s/deployments/logstash-deployment.yaml
@@ -35,7 +35,7 @@ spec:
             periodSeconds: 10
           resources:
             requests:
-              cpu: "200m"
+              cpu: "100m" # Was 200m
               memory: "512Mi"
             limits:
               cpu: "1"

--- a/deploy/k8s/deployments/prometheus-deployment.yaml
+++ b/deploy/k8s/deployments/prometheus-deployment.yaml
@@ -44,7 +44,7 @@ spec:
             periodSeconds: 10
           resources:
             requests:
-              cpu: "200m"
+              cpu: "100m" # Was 200m
               memory: "512Mi"
             limits:
               cpu: "1"

--- a/deploy/k8s/deployments/service-registry-deployment.yaml
+++ b/deploy/k8s/deployments/service-registry-deployment.yaml
@@ -46,7 +46,7 @@ spec:
             periodSeconds: 10
           resources:
             requests:
-              cpu: "100m"
+              cpu: "75m"  # Was 100m
               memory: "256Mi"
             limits:
               cpu: "500m"

--- a/deploy/k8s/deployments/zipkin-deployment.yaml
+++ b/deploy/k8s/deployments/zipkin-deployment.yaml
@@ -34,7 +34,7 @@ spec:
             periodSeconds: 10
           resources:
             requests:
-              cpu: "100m"
+              cpu: "50m"  # Was 100m
               memory: "256Mi"
             limits:
               cpu: "1"

--- a/deploy/k8s/statefulsets/elasticsearch-statefulset.yaml
+++ b/deploy/k8s/statefulsets/elasticsearch-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
               mountPath: /usr/share/elasticsearch/data
           resources:
             requests:
-              cpu: "500m"
+              cpu: "250m" # Was 500m
               memory: "1Gi"
             limits:
               cpu: "1"

--- a/deploy/k8s/statefulsets/mysql-department-statefulset.yaml
+++ b/deploy/k8s/statefulsets/mysql-department-statefulset.yaml
@@ -72,7 +72,7 @@ spec:
               mountPath: /docker-entrypoint-initdb.d
           resources:
             requests:
-              cpu: "200m"
+              cpu: "100m" # Was 200m
               memory: "512Mi"
             limits:
               cpu: "500m"

--- a/deploy/k8s/statefulsets/mysql-employee-statefulset.yaml
+++ b/deploy/k8s/statefulsets/mysql-employee-statefulset.yaml
@@ -72,7 +72,7 @@ spec:
               mountPath: /docker-entrypoint-initdb.d
           resources:
             requests:
-              cpu: "200m"
+              cpu: "100m" # Was 200m
               memory: "512Mi"
             limits:
               cpu: "500m"

--- a/deploy/k8s/statefulsets/rabbitmq-statefulset.yaml
+++ b/deploy/k8s/statefulsets/rabbitmq-statefulset.yaml
@@ -52,7 +52,7 @@ spec:
               mountPath: /var/lib/rabbitmq
           resources:
             requests:
-              cpu: "200m"
+              cpu: "100m" # Was 200m
               memory: "512Mi"
             limits:
               cpu: "1"

--- a/resource_optimization.md
+++ b/resource_optimization.md
@@ -1,0 +1,44 @@
+# Resource Optimization Summary
+
+This document summarizes the CPU resource request adjustments made to the Kubernetes deployments and statefulsets to address scheduling issues due to insufficient CPU on the OKE cluster (2 nodes, 1 OCPU/6GB RAM per node).
+
+**Total Available CPU:** 2000m (2 nodes * 1000m/node)
+**Original Total CPU Requests:** 3050m
+**New Total CPU Requests:** 1675m
+
+## Changes Made:
+
+The following table details the original and new CPU requests (`resources.requests.cpu`) for each modified service. Memory requests were kept the same as the primary issue was CPU. Limits were also largely unchanged but should be monitored.
+
+| Service YAML File                          | Original CPU Request | New CPU Request | Change (Saved) |
+|--------------------------------------------|----------------------|-----------------|----------------|
+| `deployments/adminer-deployment.yaml`          | `50m`                | `25m`           | `25m`          |
+| `deployments/api-gateway-deployment.yaml`    | `250m`               | `150m`          | `100m`         |
+| `deployments/config-server-deployment.yaml`  | `250m`               | `150m`          | `100m`         |
+| `deployments/department-service-deployment.yaml` | `250m`               | `150m`          | `100m`         |
+| `deployments/employee-service-deployment.yaml` | `250m`               | `150m`          | `100m`         |
+| `deployments/frontend-deployment.yaml`         | `100m`               | `75m`           | `25m`          |
+| `deployments/grafana-deployment.yaml`        | `100m`               | `50m`           | `50m`          |
+| `deployments/kibana-deployment.yaml`         | `100m`               | `50m`           | `50m`          |
+| `deployments/logstash-deployment.yaml`       | `200m`               | `100m`          | `100m`         |
+| `deployments/prometheus-deployment.yaml`     | `200m`               | `100m`          | `100m`         |
+| `deployments/service-registry-deployment.yaml`| `100m`               | `75m`           | `25m`          |
+| `deployments/zipkin-deployment.yaml`         | `100m`               | `50m`           | `50m`          |
+| `statefulsets/elasticsearch-statefulset.yaml`| `500m`               | `250m`          | `250m`         |
+| `statefulsets/mysql-department-statefulset.yaml`| `200m`              | `100m`          | `100m`         |
+| `statefulsets/mysql-employee-statefulset.yaml`| `200m`              | `100m`          | `100m`         |
+| `statefulsets/rabbitmq-statefulset.yaml`     | `200m`               | `100m`          | `100m`         |
+| **Total Saved**                            |                      |                 | **`1375m`**    |
+
+## Future Considerations:
+
+*   **Performance Monitoring:** Closely monitor application performance. If critical services are too slow, you may need to:
+    *   Further reduce CPU requests for less critical/background services.
+    *   Temporarily scale down non-essential services to 0 replicas.
+    *   Allocate slightly more CPU to the struggling critical services while still staying under the 2000m total.
+*   **Memory Usage:** While this intervention focused on CPU, keep an eye on memory usage as well. If pods experience OOMKilled events, memory requests/limits may also need adjustment.
+*   **Horizontal Pod Autoscaling (HPA):** If not already in use, consider implementing HPA for stateless services. This can help manage resources more dynamically but requires careful tuning of metrics and request/limit settings.
+*   **Node Resource Upgrade:** If performance remains an issue across multiple services and further optimization of requests isn't viable, the long-term solution would be to increase OCPU capacity in your OKE node pool.
+*   **Resource Quotas and LimitRanges:** Consider defining ResourceQuotas per namespace and LimitRanges to enforce sensible defaults for requests and limits, preventing future overallocation issues.
+
+This optimization aims to allow all workloads to be scheduled. Further fine-tuning will likely be necessary based on observed performance and specific application needs.


### PR DESCRIPTION
- Reduced CPU requests for all deployments and statefulsets to fit within the existing 2-node OKE cluster capacity (1 OCPU/node).
- Total CPU requests lowered from 3050m to 1675m.
- Added resource_optimization.md detailing the changes and providing guidance for future resource management.